### PR TITLE
Bugfix/find not eagerloading in repository

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -135,7 +135,7 @@ class Build : NukeBuild
         {
             Log.Information("Generating NuGet packages for projects in solution");
             int commitNum = 0;
-            string NuGetVersionCustom = "2.0.0.884";
+            string NuGetVersionCustom = "2.0.0.885";
 
 
             //if it's not a tagged release - append the commit number to the package version

--- a/Src/RCommon.EfCore/Crud/EFCoreRepository.cs
+++ b/Src/RCommon.EfCore/Crud/EFCoreRepository.cs
@@ -90,12 +90,13 @@ namespace RCommon.Persistence.EFCore.Crud
 
         public override IEagerLoadableQueryable<TEntity> Include(Expression<Func<TEntity, object>> path)
         {
-            _includableQueryable = RepositoryQuery.Include(path);
+            _includableQueryable = ObjectContext.Set<TEntity>().Include(path);
             return this;
         }
 
         public override IEagerLoadableQueryable<TEntity> ThenInclude<TPreviousProperty, TProperty>(Expression<Func<object, TProperty>> path)
         {
+            // TODO: This is likely a bug. The received is incorrect. 
             _repositoryQuery = _includableQueryable.ThenInclude(path);
             return this;
         }

--- a/Tests/RCommon.Persistence.EFCore.Tests/EFCoreRepositoryIntegrationTests.cs
+++ b/Tests/RCommon.Persistence.EFCore.Tests/EFCoreRepositoryIntegrationTests.cs
@@ -748,5 +748,34 @@ namespace RCommon.Persistence.EFCore.Tests
             Assert.That(savedCustomer.Orders.Count == 10);
         }
 
+        [Test]
+        public async Task Can_Eager_Load_Repository_And_Find_Async()
+        {
+            var testData = new List<Customer>();
+
+            // Generate Test Data
+            var repo = new TestRepository(this.ServiceProvider);
+            repo.PersistSeedData(testData);
+
+            var customer = TestDataActions.CreateCustomerStub();
+            for (int i = 0; i < 10; i++)
+            {
+                var order = TestDataActions.CreateOrderStub(x => x.Customer = customer);
+                customer.Orders.Add(order);
+                testData.Add(customer);
+            }
+            repo.PersistSeedData(testData);
+
+            var customerRepo = this.ServiceProvider.GetService<IGraphRepository<Customer>>();
+            customerRepo.Include(x => x.Orders);
+            var savedCustomer = await customerRepo
+                    .FindAsync(customer.Id);
+
+            Assert.That(savedCustomer != null);
+            Assert.That(savedCustomer.Id == customer.Id);
+            Assert.That(savedCustomer.Orders != null);
+            Assert.That(savedCustomer.Orders.Count == 10);
+        }
+
     }
 }


### PR DESCRIPTION
Updated EFCoreRepository to eager load using ObjectContext.Set<TEntity> rather than RepositoryQuery as RepositoryQuery is not used throughout repository methods.