### PR TITLE
Removed event interfaces from Core to eliminate downstream contracts 

### DIFF
--- a/Build/Build.cs
+++ b/Build/Build.cs
@@ -135,7 +135,7 @@ class Build : NukeBuild
         {
             Log.Information("Generating NuGet packages for projects in solution");
             int commitNum = 0;
-            string NuGetVersionCustom = "2.1.1.4";
+            string NuGetVersionCustom = "2.1.2.0";
 
 
             //if it's not a tagged release - append the commit number to the package version

--- a/Examples/EventHandling/Examples.EventHandling.InMemoryEventBus/TestEvent.cs
+++ b/Examples/EventHandling/Examples.EventHandling.InMemoryEventBus/TestEvent.cs
@@ -1,4 +1,5 @@
 ﻿using RCommon.EventHandling;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Examples/EventHandling/Examples.EventHandling.MediatR/TestEvent.cs
+++ b/Examples/EventHandling/Examples.EventHandling.MediatR/TestEvent.cs
@@ -1,7 +1,7 @@
 ﻿using MediatR;
-using RCommon.EventHandling;
 using RCommon.Mediator;
 using RCommon.Mediator.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Examples/Messaging/Examples.Messaging.MassTransit/TestEvent.cs
+++ b/Examples/Messaging/Examples.Messaging.MassTransit/TestEvent.cs
@@ -1,4 +1,4 @@
-﻿using RCommon.EventHandling;
+﻿using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Examples/Messaging/Examples.Messaging.Wolverine/TestEvent.cs
+++ b/Examples/Messaging/Examples.Messaging.Wolverine/TestEvent.cs
@@ -1,4 +1,4 @@
-﻿using RCommon.EventHandling;
+﻿using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Core/EventHandling/InMemoryEventBusBuilderExtensions.cs
+++ b/Src/RCommon.Core/EventHandling/InMemoryEventBusBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using RCommon.EventHandling.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Core/EventHandling/Producers/IEventProducer.cs
+++ b/Src/RCommon.Core/EventHandling/Producers/IEventProducer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RCommon.Models.Events;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Src/RCommon.Core/EventHandling/Producers/IEventRouter.cs
+++ b/Src/RCommon.Core/EventHandling/Producers/IEventRouter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using RCommon.Models.Events;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace RCommon.EventHandling.Producers

--- a/Src/RCommon.Core/EventHandling/Producers/InMemoryTransactionalEventRouter.cs
+++ b/Src/RCommon.Core/EventHandling/Producers/InMemoryTransactionalEventRouter.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using RCommon.Models.Events;
 
 namespace RCommon.EventHandling.Producers
 {

--- a/Src/RCommon.Core/EventHandling/Producers/PublishWithEventBusEventProducer.cs
+++ b/Src/RCommon.Core/EventHandling/Producers/PublishWithEventBusEventProducer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Core/RCommon.Core.csproj
+++ b/Src/RCommon.Core/RCommon.Core.csproj
@@ -12,4 +12,8 @@
 		<PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <ProjectReference Include="..\RCommon.Models\RCommon.Models.csproj" />
+	</ItemGroup>
+
 </Project>

--- a/Src/RCommon.EfCore/Crud/EFCoreRepository.cs
+++ b/Src/RCommon.EfCore/Crud/EFCoreRepository.cs
@@ -243,6 +243,21 @@ namespace RCommon.Persistence.EFCore.Crud
             return query.Skip((pageNumber - 1) * pageSize).Take(pageSize);
         }
 
+        public override IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression,
+            bool orderByAscending)
+        {
+            IQueryable<TEntity> query;
+            if (orderByAscending)
+            {
+                query = FindCore(expression).OrderBy(orderByExpression);
+            }
+            else
+            {
+                query = FindCore(expression).OrderByDescending(orderByExpression);
+            }
+            return query;
+        }
+
         public override IQueryable<TEntity> FindQuery(IPagedSpecification<TEntity> specification)
         {
             return this.FindQuery(specification.Predicate, specification.OrderByExpression, 

--- a/Src/RCommon.Entities/BusinessEntity.cs
+++ b/Src/RCommon.Entities/BusinessEntity.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations.Schema;
 using RCommon.EventHandling;
+using RCommon.Models.Events;
 
 namespace RCommon.Entities
 {

--- a/Src/RCommon.Entities/IBusinessEntity.cs
+++ b/Src/RCommon.Entities/IBusinessEntity.cs
@@ -1,4 +1,5 @@
 ﻿using RCommon.EventHandling;
+using RCommon.Models.Events;
 using System.Collections.Generic;
 
 namespace RCommon.Entities

--- a/Src/RCommon.Entities/TransactionalEventsChangedEventArgs.cs
+++ b/Src/RCommon.Entities/TransactionalEventsChangedEventArgs.cs
@@ -1,4 +1,4 @@
-﻿using RCommon.EventHandling;
+﻿using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Linq2Db/Crud/Linq2DbRepository.cs
+++ b/Src/RCommon.Linq2Db/Crud/Linq2DbRepository.cs
@@ -224,6 +224,21 @@ namespace RCommon.Persistence.Linq2Db.Crud
                  specification.OrderByAscending, specification.PageNumber, specification.PageSize);
         }
 
+        public override IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression,
+            bool orderByAscending)
+        {
+            IQueryable<TEntity> query;
+            if (orderByAscending)
+            {
+                query = FindCore(expression).OrderBy(orderByExpression);
+            }
+            else
+            {
+                query = FindCore(expression).OrderByDescending(orderByExpression);
+            }
+            return query;
+        }
+
         public async override Task<TEntity> FindSingleOrDefaultAsync(Expression<Func<TEntity, bool>> expression, CancellationToken token = default)
         {
             return await RepositoryQuery.SingleOrDefaultAsync(expression, token);

--- a/Src/RCommon.MassTransit/MassTransitEventHandlingBuilderExtensions.cs
+++ b/Src/RCommon.MassTransit/MassTransitEventHandlingBuilderExtensions.cs
@@ -12,6 +12,7 @@ using RCommon.EventHandling.Producers;
 using RCommon.EventHandling.Subscribers;
 using RCommon.MassTransit;
 using RCommon.MassTransit.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.MassTransit/Producers/PublishWithMassTransitEventProducer.cs
+++ b/Src/RCommon.MassTransit/Producers/PublishWithMassTransitEventProducer.cs
@@ -1,8 +1,8 @@
 ﻿using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Producers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.MassTransit/Producers/SendWithMassTransitEventProducer.cs
+++ b/Src/RCommon.MassTransit/Producers/SendWithMassTransitEventProducer.cs
@@ -1,8 +1,8 @@
 ﻿using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Producers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.MassTransit/Subscribers/IMassTransitEventHandler.cs
+++ b/Src/RCommon.MassTransit/Subscribers/IMassTransitEventHandler.cs
@@ -1,5 +1,5 @@
 ﻿using MassTransit;
-using RCommon.EventHandling;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.MassTransit/Subscribers/MassTransitEventHandler.cs
+++ b/Src/RCommon.MassTransit/Subscribers/MassTransitEventHandler.cs
@@ -1,7 +1,7 @@
 ﻿using MassTransit;
 using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Mediatr/MediatREventHandlingBuilderExtensions.cs
+++ b/Src/RCommon.Mediatr/MediatREventHandlingBuilderExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Subscribers;
 using RCommon.Mediator;
 using RCommon.Mediator.MediatR;
 using RCommon.Mediator.Subscribers;
 using RCommon.MediatR.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Mediatr/Producers/PublishWithMediatREventProducer.cs
+++ b/Src/RCommon.Mediatr/Producers/PublishWithMediatREventProducer.cs
@@ -1,10 +1,10 @@
 ﻿using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Producers;
 using RCommon.Mediator;
 using RCommon.MediatR.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Mediatr/Producers/SendWithMediatREventProducer.cs
+++ b/Src/RCommon.Mediatr/Producers/SendWithMediatREventProducer.cs
@@ -1,5 +1,4 @@
-﻿using RCommon.EventHandling;
-using RCommon.EventHandling.Producers;
+﻿using RCommon.EventHandling.Producers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +9,7 @@ using RCommon.MediatR.Subscribers;
 using RCommon.Mediator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using RCommon.Models.Events;
 
 namespace RCommon.MediatR.Producers
 {

--- a/Src/RCommon.Mediatr/Subscribers/MediatREventHandler.cs
+++ b/Src/RCommon.Mediatr/Subscribers/MediatREventHandler.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using RCommon.EventHandling;
+using RCommon.Models.Events;
 using RCommon.EventHandling.Subscribers;
 using RCommon.Mediator.MediatR;
 using System;

--- a/Src/RCommon.Models/Events/IAsyncEvent.cs
+++ b/Src/RCommon.Models/Events/IAsyncEvent.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RCommon.EventHandling
+namespace RCommon.Models.Events
 {
     public interface IAsyncEvent : ISerializableEvent
     {

--- a/Src/RCommon.Models/Events/ISerializableEvent.cs
+++ b/Src/RCommon.Models/Events/ISerializableEvent.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RCommon.EventHandling
+namespace RCommon.Models.Events
 {
     public interface ISerializableEvent
     {

--- a/Src/RCommon.Models/Events/ISyncEvent.cs
+++ b/Src/RCommon.Models/Events/ISyncEvent.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace RCommon.EventHandling
+namespace RCommon.Models.Events
 {
     public interface ISyncEvent : ISerializableEvent
     {

--- a/Src/RCommon.Models/IPaginatedListRequest.cs
+++ b/Src/RCommon.Models/IPaginatedListRequest.cs
@@ -3,7 +3,7 @@
     public interface IPaginatedListRequest : IModel
     {
         int PageNumber { get; set; }
-        int? PageSize { get; set; }
+        int PageSize { get; set; }
         string SortBy { get; set; }
         SortDirectionEnum SortDirection { get; set; }
     }

--- a/Src/RCommon.Models/PaginatedListModel.cs
+++ b/Src/RCommon.Models/PaginatedListModel.cs
@@ -17,27 +17,12 @@ namespace RCommon.Models
         where TOut : class
     {
 
-        private Expression<Func<TSource, object>> _sortExpression = null;
-
-        protected PaginatedListModel(IQueryable<TSource> source, PaginatedListRequest paginatedListRequest, bool skipTotal = false)
+        protected PaginatedListModel(IOrderedQueryable<TSource> source, PaginatedListRequest paginatedListRequest)
         {
-            PaginateQueryable(source, paginatedListRequest, skipTotal);
+            PaginateQueryable(source, paginatedListRequest);
         }
 
-        private IQueryable<TSource> Sort(IQueryable<TSource> source)
-        {
-
-            if (this._sortExpression == null)
-            {
-                return source;
-            }
-
-            return SortDirection == SortDirectionEnum.Descending
-                ? source.OrderByDescending(this._sortExpression)
-                : source.OrderBy(this._sortExpression);
-        }
-
-        protected void PaginateQueryable(IQueryable<TSource> source, PaginatedListRequest paginatedListRequest, bool skipTotal = false, bool skipSort = false)
+        protected void PaginateQueryable(IOrderedQueryable<TSource> source, PaginatedListRequest paginatedListRequest)
         {
             if (source == null)
             {
@@ -51,38 +36,23 @@ namespace RCommon.Models
 
             SortBy = paginatedListRequest.SortBy ?? "id";
             SortDirection = paginatedListRequest.SortDirection;
-
             PageSize = paginatedListRequest.PageSize;
             PageNumber = paginatedListRequest.PageNumber;
+            TotalCount = source.Count();
+            TotalPages = TotalCount / PageSize + (TotalCount % PageSize > 0 ? 1 : 0);
 
-            if (!skipTotal)
-            {
-                TotalCount = source.Count();
-                TotalPages = TotalCount / PageSize + (TotalCount % PageSize > 0 ? 1 : 0) ?? 1;
-            }
-
-            var query = skipSort ? source : Sort(source);
-
-            if (PageSize.HasValue)
-            {
-                query = query.Skip(PageSize.Value * (PageNumber - 1)).Take(PageSize.Value);
-            }
+            var query = source.Skip(PageSize * (PageNumber - 1)).Take(PageSize);
 
             Items = CastItems(query).ToList();
         }
 
         protected abstract IQueryable<TOut> CastItems(IQueryable<TSource> source);
 
-        public virtual Expression<Func<TSource, object>> GetSortExpression()
-        {
-            return _sortExpression;
-        }
-
         [DataMember]
         public List<TOut> Items { get; set; }
 
         [DataMember]
-        public int? PageSize { get; set; }
+        public int PageSize { get; set; }
 
         [DataMember]
         public int PageNumber { get; set; }
@@ -127,27 +97,12 @@ namespace RCommon.Models
         where TSource : class
     {
 
-        private Expression<Func<TSource, object>> _sortExpression = null;
-
-        protected PaginatedListModel(IQueryable<TSource> source, PaginatedListRequest paginatedListRequest, bool skipTotal = false)
+        protected PaginatedListModel(IOrderedQueryable<TSource> source, PaginatedListRequest paginatedListRequest)
         {
-            PaginateQueryable(source, paginatedListRequest, skipTotal);
+            PaginateQueryable(source, paginatedListRequest);
         }
 
-        private IQueryable<TSource> Sort(IQueryable<TSource> source)
-        {
-
-            if (this._sortExpression == null)
-            {
-                return source;
-            }
-
-            return SortDirection == SortDirectionEnum.Descending
-                ? source.OrderByDescending(this._sortExpression)
-                : source.OrderBy(this._sortExpression);
-        }
-
-        protected void PaginateQueryable(IQueryable<TSource> source, PaginatedListRequest paginatedListRequest, bool skipTotal = false, bool skipSort = false)
+        protected void PaginateQueryable(IOrderedQueryable<TSource> source, PaginatedListRequest paginatedListRequest)
         {
             if (source == null)
             {
@@ -161,36 +116,19 @@ namespace RCommon.Models
 
             SortBy = paginatedListRequest.SortBy ?? "id";
             SortDirection = paginatedListRequest.SortDirection;
-
             PageSize = paginatedListRequest.PageSize;
             PageNumber = paginatedListRequest.PageNumber;
+            TotalCount = source.Count();
+            TotalPages = TotalCount / PageSize + (TotalCount % PageSize > 0 ? 1 : 0);
 
-            if (!skipTotal)
-            {
-                TotalCount = source.Count();
-                TotalPages = TotalCount / PageSize + (TotalCount % PageSize > 0 ? 1 : 0) ?? 1;
-            }
-
-            var query = skipSort ? source : Sort(source);
-
-            if (PageSize.HasValue)
-            {
-                query = query.Skip(PageSize.Value * (PageNumber - 1)).Take(PageSize.Value);
-            }
-
-            Items = query.ToList();
-        }
-
-        public virtual Expression<Func<TSource, object>> GetSortExpression()
-        {
-            return _sortExpression;
+            Items = source.Skip(PageSize * (PageNumber - 1)).Take(PageSize).ToList();
         }
 
         [DataMember]
         public List<TSource> Items { get; set; }
 
         [DataMember]
-        public int? PageSize { get; set; }
+        public int PageSize { get; set; }
 
         [DataMember]
         public int PageNumber { get; set; }

--- a/Src/RCommon.Models/PaginatedListRequest.cs
+++ b/Src/RCommon.Models/PaginatedListRequest.cs
@@ -18,7 +18,7 @@ namespace RCommon.Models
         public virtual int PageNumber { get; set; }
 
         [DataMember]
-        public virtual int? PageSize { get; set; }
+        public virtual int PageSize { get; set; }
 
         [DataMember]
         public virtual string SortBy { get; set; }

--- a/Src/RCommon.Persistence.Caching/Crud/CachingGraphRepository.cs
+++ b/Src/RCommon.Persistence.Caching/Crud/CachingGraphRepository.cs
@@ -75,6 +75,11 @@ namespace RCommon.Persistence.Caching.Crud
             return _repository.FindQuery(expression, orderByExpression, orderByAscending, pageNumber, pageSize);
         }
 
+        public IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression, bool orderByAscending)
+        {
+            return _repository.FindQuery(expression, orderByExpression, orderByAscending);
+        }
+
         public IQueryable<TEntity> FindQuery(IPagedSpecification<TEntity> specification)
         {
             return _repository.FindQuery(specification);

--- a/Src/RCommon.Persistence.Caching/Crud/CachingLinqRepository.cs
+++ b/Src/RCommon.Persistence.Caching/Crud/CachingLinqRepository.cs
@@ -73,6 +73,11 @@ namespace RCommon.Persistence.Caching.Crud
             return _repository.FindQuery(expression, orderByExpression, orderByAscending, pageNumber, pageSize);
         }
 
+        public IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression, bool orderByAscending)
+        {
+            return _repository.FindQuery(expression, orderByExpression, orderByAscending);
+        }
+
         public IQueryable<TEntity> FindQuery(IPagedSpecification<TEntity> specification)
         {
             return _repository.FindQuery(specification);

--- a/Src/RCommon.Persistence/Crud/ILinqRepository.cs
+++ b/Src/RCommon.Persistence/Crud/ILinqRepository.cs
@@ -21,6 +21,9 @@ namespace RCommon.Persistence.Crud
             bool orderByAscending, int pageNumber = 1, int pageSize = 0);
         IQueryable<TEntity> FindQuery(IPagedSpecification<TEntity> specification);
 
+        IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression,
+            bool orderByAscending);
+
         Task<IPaginatedList<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression,
             bool orderByAscending, int pageNumber = 1, int pageSize = 0,
             CancellationToken token = default);

--- a/Src/RCommon.Persistence/Crud/LinqRepositoryBase.cs
+++ b/Src/RCommon.Persistence/Crud/LinqRepositoryBase.cs
@@ -123,6 +123,8 @@ namespace RCommon.Persistence.Crud
 
         public abstract IQueryable<TEntity> FindQuery(ISpecification<TEntity> specification);
         public abstract IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression);
+        public abstract IQueryable<TEntity> FindQuery(Expression<Func<TEntity, bool>> expression, Expression<Func<TEntity, object>> orderByExpression,
+            bool orderByAscending);
         public abstract Task AddAsync(TEntity entity, CancellationToken token = default);
         public abstract Task DeleteAsync(TEntity entity, CancellationToken token = default);
         public abstract Task UpdateAsync(TEntity entity, CancellationToken token = default);

--- a/Src/RCommon.Wolverine/Producers/PublishWithWolverineEventProducer.cs
+++ b/Src/RCommon.Wolverine/Producers/PublishWithWolverineEventProducer.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Configuration;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Producers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Wolverine/Producers/SendWithWolverineEventProducer.cs
+++ b/Src/RCommon.Wolverine/Producers/SendWithWolverineEventProducer.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Producers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Src/RCommon.Wolverine/Subscribers/IWolverineEventHandler.cs
+++ b/Src/RCommon.Wolverine/Subscribers/IWolverineEventHandler.cs
@@ -1,10 +1,10 @@
 ﻿using Wolverine;
-using RCommon.EventHandling;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using RCommon.Models.Events;
 
 namespace RCommon.MassTransit.Subscribers
 {

--- a/Src/RCommon.Wolverine/Subscribers/WolverineEventHandler.cs
+++ b/Src/RCommon.Wolverine/Subscribers/WolverineEventHandler.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
-using RCommon.EventHandling;
 using RCommon.EventHandling.Subscribers;
+using RCommon.Models.Events;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Removed event interfaces from Core to eliminate downstream contracts dependency on it.