### PR TITLE
Fix flaky ClaimTypesConst tests

### DIFF
--- a/Tests/RCommon.Security.Tests/AssemblyInfo.cs
+++ b/Tests/RCommon.Security.Tests/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using Xunit;
+
+// Several test classes in this assembly exercise ClaimTypesConst, which is a process-wide mutable
+// static (configure-once-at-startup). ClaimTypesConstTests and ClaimsIdentityExtensionsTests both
+// call the internal ClaimTypesConst.Reset() in their constructor/Dispose for isolation. Under xUnit's
+// default per-class parallelism these classes race on that global: a parallel Reset() can null the
+// options mid-test, so a subsequent property read rebuilds defaults and a configured value (e.g. a
+// custom Role) reverts to the default claim URI. Serialize the assembly's tests to make the shared
+// static state deterministic.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
ClaimTypesConstTests.Configure_AppliesCustomValues intermittently failed on CI (seeing the default role claim URI instead of the configured "roles"). Root cause is a cross-class race on the process-wide mutable static ClaimTypesConst: both ClaimTypesConstTests and ClaimsIdentityExtensionsTests call the internal Reset() in ctor/Dispose, and under xUnit's default per-class parallelism a parallel Reset() can null the options mid-test so a later property read rebuilds defaults.

Disable test parallelization for RCommon.Security.Tests so the shared static state is deterministic. Pre-existing flake, unrelated to the 3.1.1 changes; it blocked the release CI run.